### PR TITLE
Update log.c

### DIFF
--- a/mft/log.c
+++ b/mft/log.c
@@ -279,10 +279,10 @@ void
 mft_log_perror(int log_level,int eno,const char *message)
 {
 	if(eno<0) eno=-eno;
-	if(eno>sys_nerr)
+	if(eno>errno)
 		return;
 	
-	mft_logf(log_level,"%s: %s",message,sys_errlist[eno]);
+	mft_logf(log_level,"%s: %s",message,strerror(eno));
 	return;
 }
 


### PR DESCRIPTION
sys_nerr and sys_errlist depricated. Now using errno and strerror()

I still ran into some build errors that required sgml2latex which I got from linuxdoc-tools.
This time it actually asked for latex so I installed latex-make.
This allowed the build to complete. I suspect one would only need latex-make and gcc-multilib to complete this build.

This is my fix to [issue 3](https://github.com/CameronLonsdale/bmap/issues/3) and I'm not sure if there's a simple way (or much how to on my side yet) to update the requirements list.